### PR TITLE
Fixed missing spread operator

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -164,7 +164,7 @@ export class Service<R extends Resource = Resource> {
     }
 
     public delete(id: string, params?: Object): Observable<void> {
-        params = { ...{}, ...Base.ParamsResource, params };
+        params = { ...{}, ...Base.ParamsResource, ...params };
 
         // http request
         let path = new PathBuilder();


### PR DESCRIPTION
Due to the missing spread operator the `params` passed to delete was effectively ignored.

Also, is there any particular reason for `params` not being typed as `IParamsResource` in the following?

https://github.com/reyesoft/ngx-jsonapi/blob/714cda61a36f56fbad60ed8859f5cfaf9cd451b7/src/service.ts#L166