### PR TITLE
Added meta to POST and PATCH requests

### DIFF
--- a/src/interfaces/params.ts
+++ b/src/interfaces/params.ts
@@ -2,4 +2,5 @@ export interface IParams {
     beforepath?: string;
     include?: Array<string>;
     ttl?: number;
+    meta?: {[key: string]: any};
 }

--- a/src/resource.spec.ts
+++ b/src/resource.spec.ts
@@ -7,8 +7,6 @@ import { IDataCollection } from './interfaces/data-collection';
 import { of } from 'rxjs';
 
 describe('resource', () => {
-    let resource = new Resource();
-
     // it('should be reset()', () => {
     //     resource.id = 'some-id';
     //     expect(resource.id).toBe('some-id');
@@ -17,6 +15,7 @@ describe('resource', () => {
     // });
 
     it('should save the resource without relationships that dont refer to a resource or mean to remove the relationship', async () => {
+        let resource = new Resource();
         spyOn(resource, 'getService').and.returnValue(false);
         spyOn(PathBuilder.prototype, 'applyParams');
         resource.id = '1234';
@@ -65,5 +64,111 @@ describe('resource', () => {
             content: 'resource'
         };
         expect(exec_spy).toHaveBeenCalledWith('1234', 'PATCH', second_expected_resource_in_save, true);
+    });
+
+    it('if set, te save method should send the "meta" property when saving a resource', async () => {
+        let resource = new Resource();
+        spyOn(resource, 'getService').and.returnValue(false);
+        spyOn(PathBuilder.prototype, 'applyParams');
+        resource.id = '1234';
+        resource.type = 'tests';
+        resource.attributes = { name: 'test_name' };
+        resource.relationships = {
+            has_one_relationship: new DocumentResource(),
+            has_many_relationship: new DocumentCollection()
+        };
+        resource.links = {};
+        resource.is_new = true;
+        resource.is_saving = false;
+        resource.is_loading = false;
+        resource.source = 'store';
+        resource.cache_last_update = 0;
+        resource.relationships = {};
+        resource.meta = { some_data: 'some_data'};
+        let response = Object.create(resource);
+        let exec_spy = spyOn(Core, 'exec').and.returnValue(of({ data: response }));
+        await resource.save();
+        let expected_resource_in_save = {
+            data: {
+                type: 'tests',
+                id: '1234',
+                attributes: { name: 'test_name' },
+                relationships: {},
+                meta: { some_data: 'some_data' }
+            },
+            builded: false,
+            content: 'resource'
+        };
+        expect(exec_spy).toHaveBeenCalledWith('1234', 'PATCH', expected_resource_in_save, true);
+    });
+
+    it('top level meta object should be included in the request if available', async () => {
+        let resource = new Resource();
+        spyOn(resource, 'getService').and.returnValue(false);
+        spyOn(PathBuilder.prototype, 'applyParams');
+        resource.id = '1234';
+        resource.type = 'tests';
+        resource.attributes = { name: 'test_name' };
+        resource.relationships = {
+            has_one_relationship: new DocumentResource(),
+            has_many_relationship: new DocumentCollection()
+        };
+        resource.links = {};
+        resource.is_new = true;
+        resource.is_saving = false;
+        resource.is_loading = false;
+        resource.source = 'store';
+        resource.cache_last_update = 0;
+        resource.relationships = {};
+        let response = Object.create(resource);
+        let exec_spy = spyOn(Core, 'exec').and.returnValue(of({ data: response }));
+        await resource.save({meta: {restore: true}});
+        let expected_resource_in_save = {
+            data: {
+                type: 'tests',
+                id: '1234',
+                attributes: { name: 'test_name' },
+                relationships: {}
+            },
+            builded: false,
+            meta: { restore: true },
+            content: 'resource'
+        };
+        expect(exec_spy).toHaveBeenCalledWith('1234', 'PATCH', expected_resource_in_save, true);
+    });
+
+    it('restore method should set top level meta to restore the resource (according to Reyesoft specification extension)', async () => {
+        let resource = new Resource();
+        spyOn(resource, 'getService').and.returnValue(false);
+        spyOn(PathBuilder.prototype, 'applyParams');
+        resource.id = '1234';
+        resource.type = 'tests';
+        resource.attributes = { name: 'test_name' };
+        resource.relationships = {
+            has_one_relationship: new DocumentResource(),
+            has_many_relationship: new DocumentCollection()
+        };
+        resource.links = {};
+        resource.is_new = true;
+        resource.is_saving = false;
+        resource.is_loading = false;
+        resource.source = 'store';
+        resource.cache_last_update = 0;
+        resource.relationships = {};
+        let response = Object.create(resource);
+        let exec_spy = spyOn(Core, 'exec').and.returnValue(of({ data: response }));
+        await resource.restore();
+        let expected_resource_in_save = {
+            data: {
+                type: 'tests',
+                id: '1234',
+                attributes: { name: 'test_name' },
+                relationships: {}
+            },
+            builded: false,
+            meta: { restore: true },
+            content: 'resource'
+        };
+        expect(exec_spy).toHaveBeenCalledWith('1234', 'PATCH', expected_resource_in_save, true);
     });
 });

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -19,6 +19,7 @@ export class Resource implements ICacheable {
     public attributes: IAttributes = {};
     public relationships: IRelationships = {};
     public links: ILinks = {};
+    public meta: {[key: string]: any};
 
     public is_new = true;
     public is_saving = false;
@@ -127,6 +128,14 @@ export class Resource implements ICacheable {
             content: 'resource'
         };
 
+        if (this.meta) { // resource's meta
+            ret.data.meta = this.meta;
+        }
+
+        if (params.meta) { // top level meta
+            ret.meta = params.meta;
+        }
+
         if (included.length > 0) {
             ret.included = included;
         }
@@ -220,6 +229,12 @@ export class Resource implements ICacheable {
             (<Resource>this.relationships[resource].data).type &&
             (<Resource>this.relationships[resource].data).type !== ''
         );
+    }
+
+    public restore<T extends Resource>(params: IParamsResource = {}): Observable<object> {
+        params.meta = {...params.meta, ...{ restore: true }};
+
+        return this.save(params);
     }
 
     /*


### PR DESCRIPTION
Added meta to POST and PATCH requests. Also added a method to restore resources (resource.restore()) using Reyesoft's JSONAPI specification extension. Everything is tested.