### PR TITLE
BUGFIX: Set type of resource in service.createResource

### DIFF
--- a/src/service.spec.ts
+++ b/src/service.spec.ts
@@ -1,0 +1,62 @@
+import { Resource } from './resource';
+import { Service } from './service';
+import { Converter } from './services/converter';
+import { Core } from './core';
+import { StoreService as JsonapiStore } from './sources/store.service';
+import { Http as JsonapiHttpImported } from './sources/http.service';
+import { HttpClient, HttpEvent, HttpHandler, HttpRequest, HttpResponse } from '@angular/common/http';
+import { JsonapiConfig } from './jsonapi-config';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+class HttpHandlerMock implements HttpHandler {
+    public handle(req: HttpRequest<any>): Observable<HttpEvent<any>> {
+        let subject = new BehaviorSubject(new HttpResponse());
+
+        return subject.asObservable();
+    }
+}
+
+class MockResource extends Resource {
+    public attributes = {
+        name: '',
+        description: ''
+    };
+    public type = 'resource';
+}
+
+class MockResourcesService extends Service<MockResource> {
+    public type = 'resource';
+    public resource = MockResource;
+}
+
+describe('service methods', () => {
+    let core;
+    let service;
+
+    beforeEach(() => {
+        core = new Core(
+            new JsonapiConfig(),
+            new JsonapiStore(),
+            new JsonapiHttpImported(new HttpClient(new HttpHandlerMock()), new JsonapiConfig())
+        );
+        service = new MockResourcesService();
+        service.register();
+    });
+
+    it('a new resource has a type', () => {
+        spyOn(Converter, 'getService').and.returnValue(service);
+
+        const resource = service.new();
+        expect(resource instanceof MockResource).toBeTruthy();
+        expect(resource.type).toEqual('resource');
+    });
+
+    it('a new resource with id has a type', () => {
+        spyOn(Converter, 'getService').and.returnValue(service);
+
+        const resource = service.createResource('31');
+        expect(resource instanceof MockResource).toBeTruthy();
+        expect(resource.id).toEqual('31');
+        expect(resource.type).toEqual('resource');
+    });
+});

--- a/src/service.ts
+++ b/src/service.ts
@@ -158,7 +158,7 @@ export class Service<R extends Resource = Resource> {
 
     public createResource(id: string): R {
         let service = Converter.getService(this.type);
-        let resource = new service.resource();
+        let resource = service.new();
         resource.id = id;
         service.cachememory.setResource(resource, false);
 


### PR DESCRIPTION
When creating a resource using `new service.resource()`, the resource will be missing it's type.

When using `service.new()`, the type is set correctly.