### PR TITLE
fix/removeRelationshipLikeJsonApiSpecification

### DIFF
--- a/src/resource.spec.ts
+++ b/src/resource.spec.ts
@@ -44,9 +44,7 @@ describe('resource', () => {
                 id: '1234',
                 attributes: { name: 'test_name' },
                 relationships: {}
-            },
-            builded: false,
-            content: 'resource'
+            }
         };
         expect(exec_spy).toHaveBeenCalledWith('1234', 'PATCH', expected_resource_in_save, true);
         resource.relationships.has_many_relationship = new DocumentCollection();

--- a/src/resource.spec.ts
+++ b/src/resource.spec.ts
@@ -62,9 +62,7 @@ describe('resource', () => {
                     has_many_relationship: { data: [] },
                     has_one_relationship: { data: null }
                 }
-            },
-            builded: false,
-            content: 'resource'
+            }
         };
         expect(exec_spy).toHaveBeenCalledWith('1234', 'PATCH', second_expected_resource_in_save, true);
     });
@@ -91,8 +89,6 @@ describe('resource', () => {
             // id: '',
         };
         let to_object_resource: IDataObject = new_resource.toObject(params);
-        expect(to_object_resource.builded).toBeFalsy();
-        expect(to_object_resource.content).toBe('resource');
         expect(to_object_resource.data.id).toBe('1');
         expect(to_object_resource.data.type).toBe('main');
         expect(to_object_resource.data.attributes.main_attribute).toBe('123456789');
@@ -288,9 +284,7 @@ describe('resource', () => {
                 attributes: { name: 'test_name' },
                 relationships: {},
                 meta: { some_data: 'some_data' }
-            },
-            builded: false,
-            content: 'resource'
+            }
         };
         expect(exec_spy).toHaveBeenCalledWith('1234', 'PATCH', expected_resource_in_save, true);
     });
@@ -323,9 +317,7 @@ describe('resource', () => {
                 attributes: { name: 'test_name' },
                 relationships: {}
             },
-            builded: false,
-            meta: { restore: true },
-            content: 'resource'
+            meta: { restore: true }
         };
         expect(exec_spy).toHaveBeenCalledWith('1234', 'PATCH', expected_resource_in_save, true);
     });
@@ -358,9 +350,7 @@ describe('resource', () => {
                 attributes: { name: 'test_name' },
                 relationships: {}
             },
-            builded: false,
-            meta: { restore: true },
-            content: 'resource'
+            meta: { restore: true }
         };
         expect(exec_spy).toHaveBeenCalledWith('1234', 'PATCH', expected_resource_in_save, true);
     });

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -124,9 +124,7 @@ export class Resource implements ICacheable {
                 id: this.id,
                 attributes: attributes,
                 relationships: relationships
-            },
-            builded: false,
-            content: 'resource'
+            }
         };
 
         // resource's meta
@@ -228,7 +226,7 @@ export class Resource implements ICacheable {
         if (relation instanceof DocumentCollection) {
             relation.data = relation.data.filter(resource => resource.id !== id);
         } else {
-            relation.data.reset();
+            relation.data = null;
         }
 
         return true;


### PR DESCRIPTION
- set hasOne relationships with data=null when you call removeRelationship on resource.
- builded and content removed from toObject() return