### PR TITLE
Fix resource has one relationships

### DIFF
--- a/src/service.spec.ts
+++ b/src/service.spec.ts
@@ -321,7 +321,7 @@ for (let store_cache_method of store_cache_methods) {
             let http_response = {
                 body: TestFactory.getCollectionDocumentData(Book, 1, ['author'])
             };
-            http_response.body.included[0].relationships.books.data = [{ id: 'book_123', type: 'books'}];
+            http_response.body.included[0].relationships.books.data = [{ id: 'book_123', type: 'books' }];
             let nested_book = TestFactory.getBook();
             delete nested_book.relationships;
             nested_book.id = 'book_123';
@@ -356,7 +356,7 @@ for (let store_cache_method of store_cache_methods) {
             let http_response = {
                 body: TestFactory.getCollectionDocumentData(Book, 1, ['author'])
             };
-            http_response.body.included[0].relationships.books.data = [{ id: 'book_123', type: 'books'}];
+            http_response.body.included[0].relationships.books.data = [{ id: 'book_123', type: 'books' }];
             let nested_book = TestFactory.getBook();
             delete nested_book.relationships;
             nested_book.id = 'book_123';
@@ -395,7 +395,7 @@ for (let store_cache_method of store_cache_methods) {
             let http_response = {
                 body: TestFactory.getCollectionDocumentData(Book, 1, ['author'])
             };
-            http_response.body.included[0].relationships.books.data = [{ id: 'book_123', type: 'books'}];
+            http_response.body.included[0].relationships.books.data = [{ id: 'book_123', type: 'books' }];
             let nested_book = TestFactory.getBook();
             delete nested_book.relationships;
             nested_book.id = 'book_123';

--- a/src/service.spec.ts
+++ b/src/service.spec.ts
@@ -600,7 +600,7 @@ describe('service.all() and next service.get()', () => {
         let http_request_spy = spyOn(HttpClient.prototype, 'request');
 
         let book_emits = await booksService
-            .get('1', { include: ['author'], ttl: 1000})
+            .get('1', { include: ['author'], ttl: 1000 })
             .pipe(
                 map(emit => {
                     expect(http_request_spy).not.toHaveBeenCalled();
@@ -639,7 +639,7 @@ describe('service.all() and next service.get()', () => {
         test_response_subject.next(new HttpResponse({ body: books_api }));
 
         let books_emits = await booksService
-            .all({ include: ['author'], ttl: 1000})
+            .all({ include: ['author'], ttl: 1000 })
             .pipe(
                 map(emit => {
                     if (emit.loaded) {
@@ -819,7 +819,7 @@ describe('service.get()', () => {
         let body_resource = <IDocumentResource>TestFactory.getResourceDocumentData(Book, ['author']);
         test_response_subject.next(new HttpResponse({ body: body_resource }));
         // caching resource
-        await booksService.get('1', {include: ['author']}).toPromise();
+        await booksService.get('1', { include: ['author'] }).toPromise();
         test_response_subject.complete();
         test_response_subject = new BehaviorSubject(new HttpResponse());
 
@@ -843,45 +843,43 @@ describe('service.get()', () => {
         expect(http_request_spy).toHaveBeenCalledTimes(0);
     });
 
-    it(`with cached on store (live) resource + include cached has-one-relationship emits source ^new-store|`,
-        async () => {
-            let body_resource = <IDocumentResource>TestFactory.getResourceDocumentData(Book, ['author']);
-            // body_resource.data.relationships = { author: { data: [] } };
-            body_resource.data.id = '1';
-            test_response_subject.next(new HttpResponse({ body: body_resource }));
-            // caching resource
-            await booksService.get('1', {include: ['author']}).toPromise();
-            test_response_subject.complete();
+    it(`with cached on store (live) resource + include cached has-one-relationship emits source ^new-store|`, async () => {
+        let body_resource = <IDocumentResource>TestFactory.getResourceDocumentData(Book, ['author']);
+        // body_resource.data.relationships = { author: { data: [] } };
+        body_resource.data.id = '1';
+        test_response_subject.next(new HttpResponse({ body: body_resource }));
+        // caching resource
+        await booksService.get('1', { include: ['author'] }).toPromise();
+        test_response_subject.complete();
 
-            let cachememory = CacheMemory.getInstance(); // kill only memory cache
-            (cachememory as any).resources = {}; // kill memory cache
-            (cachememory as any).collections = {}; // kill memory cache
+        let cachememory = CacheMemory.getInstance(); // kill only memory cache
+        (cachememory as any).resources = {}; // kill memory cache
+        (cachememory as any).collections = {}; // kill memory cache
 
-            let http_request_spy = spyOn(HttpClient.prototype, 'request');
+        let http_request_spy = spyOn(HttpClient.prototype, 'request');
 
-            let expected = [
-                // expected emits
-                { loaded: false, source: 'new' },
-                { loaded: true, source: 'store' }
-            ];
+        let expected = [
+            // expected emits
+            { loaded: false, source: 'new' },
+            { loaded: true, source: 'store' }
+        ];
 
-            let emits = await booksService
-                .get('1', { ttl: 1000, include: ['author'] })
-                .pipe(
-                    map(emit => {
-                        if (emit.source !== 'new') {
-                            expect(emit.relationships.author.data.attributes.name).toBeTruthy();
-                        }
+        let emits = await booksService
+            .get('1', { ttl: 1000, include: ['author'] })
+            .pipe(
+                map(emit => {
+                    if (emit.source !== 'new') {
+                        expect(emit.relationships.author.data.attributes.name).toBeTruthy();
+                    }
 
-                        return { loaded: emit.loaded, source: emit.source };
-                    }),
-                    toArray()
-                )
-                .toPromise();
-            expect(emits).toMatchObject(expected);
-            expect(http_request_spy).not.toHaveBeenCalled();
-        }
-    );
+                    return { loaded: emit.loaded, source: emit.source };
+                }),
+                toArray()
+            )
+            .toPromise();
+        expect(emits).toMatchObject(expected);
+        expect(http_request_spy).not.toHaveBeenCalled();
+    });
 
     it(`with cached on memory (live) resource + include empty has-many-relationship emits source ^memory|`, async () => {
         let body_resource = <IDocumentResource>TestFactory.getResourceDocumentData(Author);

--- a/src/service.ts
+++ b/src/service.ts
@@ -91,7 +91,7 @@ export class Service<R extends Resource = Resource> {
         let subject = new BehaviorSubject<R>(resource);
 
         if (Object.keys(params.fields || []).length > 0) {
-            // memory/store cache dont suppont fields
+            // memory/store cache doesnt support fields
             this.getGetFromServer(path, resource, subject);
         } else if (isLive(resource, params.ttl) && relationshipsAreBuilded(resource, params.include || [])) {
             // data on memory and its live

--- a/src/services/resource-relationships-converter.ts
+++ b/src/services/resource-relationships-converter.ts
@@ -86,7 +86,11 @@ export class ResourceRelationshipsConverter {
             (<Resource>this.relationships_dest[relation_alias].data).type = relation_data_from.data.type;
         }
 
-        if ((<Resource>this.relationships_dest[relation_alias].data).id !== relation_data_from.data.id) {
+        if (
+            (<Resource>this.relationships_dest[relation_alias].data).id !== relation_data_from.data.id
+            || !(<Resource>this.relationships_dest[relation_alias].data).attributes
+            || Object.keys((<Resource>this.relationships_dest[relation_alias].data).attributes).length === 0
+        ) {
             let resource_data = this.__buildRelationship(relation_data_from.data);
             if (resource_data) {
                 this.relationships_dest[relation_alias].data = resource_data;

--- a/src/services/resource-relationships-converter.ts
+++ b/src/services/resource-relationships-converter.ts
@@ -87,9 +87,9 @@ export class ResourceRelationshipsConverter {
         }
 
         if (
-            (<Resource>this.relationships_dest[relation_alias].data).id !== relation_data_from.data.id
-            || !(<Resource>this.relationships_dest[relation_alias].data).attributes
-            || Object.keys((<Resource>this.relationships_dest[relation_alias].data).attributes).length === 0
+            (<Resource>this.relationships_dest[relation_alias].data).id !== relation_data_from.data.id ||
+            !(<Resource>this.relationships_dest[relation_alias].data).attributes ||
+            Object.keys((<Resource>this.relationships_dest[relation_alias].data).attributes).length === 0
         ) {
             let resource_data = this.__buildRelationship(relation_data_from.data);
             if (resource_data) {

--- a/src/tests/factories/test-factory.ts
+++ b/src/tests/factories/test-factory.ts
@@ -275,7 +275,7 @@ export class TestFactory {
                 if (!(<Resource>document_data.data).relationships[included_alias].data) {
                     continue;
                 }
-                TestFactory.fillResourceRelationshipsInDocumentData(document_data, (<Resource>document_data.data), included_alias);
+                TestFactory.fillResourceRelationshipsInDocumentData(document_data, <Resource>document_data.data, included_alias);
 
                 return;
             }

--- a/src/tests/factories/test-factory.ts
+++ b/src/tests/factories/test-factory.ts
@@ -175,14 +175,15 @@ export class TestFactory {
     }
 
     private static includeFromService(resource: Resource, relationship_alias: string, class_to_add: typeof Resource) {
-        if (resource.relationships[relationship_alias] && 'id' in resource.relationships[relationship_alias].data) {
+        let relationship = resource.relationships[relationship_alias];
+        if (!relationship) {
+            console.error(`${relationship_alias} relationship doesn't exist in ${resource.type}`);
+
+            return;
+        } else if (relationship.data && 'id' in relationship.data) {
             this.includeHasOneFromService(resource, relationship_alias, class_to_add);
-        } else if (resource.relationships[relationship_alias] instanceof DocumentCollection) {
+        } else if (relationship instanceof DocumentCollection) {
             this.includeHasManyFromService(resource, relationship_alias, class_to_add);
-        } else {
-            console.error(
-                `includeFromService cannot include relatioship ${relationship_alias} in resource ${resource.type} because it doesn't exist`
-            );
         }
     }
 

--- a/src/tests/factories/test-factory.ts
+++ b/src/tests/factories/test-factory.ts
@@ -271,11 +271,13 @@ export class TestFactory {
             if (!document_data.included) {
                 document_data.included = [];
             }
-            if (document_data.data instanceof Resource) {
-                if (!document_data.data.relationships[included_alias].data) {
+            if ((<Resource>document_data.data).id) {
+                if (!(<Resource>document_data.data).relationships[included_alias].data) {
                     continue;
                 }
-                TestFactory.fillResourceRelationshipsInDocumentData(document_data, document_data.data, included_alias);
+                TestFactory.fillResourceRelationshipsInDocumentData(document_data, (<Resource>document_data.data), included_alias);
+
+                return;
             }
             for (let resource of <Array<Resource>>document_data.data) {
                 TestFactory.fillResourceRelationshipsInDocumentData(document_data, resource, included_alias);

--- a/src/tests/factories/test-factory.ts
+++ b/src/tests/factories/test-factory.ts
@@ -175,7 +175,7 @@ export class TestFactory {
     }
 
     private static includeFromService(resource: Resource, relationship_alias: string, class_to_add: typeof Resource) {
-        if ('id' in resource.relationships[relationship_alias].data) {
+        if (resource.relationships[relationship_alias] && 'id' in resource.relationships[relationship_alias].data) {
             this.includeHasOneFromService(resource, relationship_alias, class_to_add);
         } else if (resource.relationships[relationship_alias] instanceof DocumentCollection) {
             this.includeHasManyFromService(resource, relationship_alias, class_to_add);

--- a/src/tests/factories/test-factory.ts
+++ b/src/tests/factories/test-factory.ts
@@ -22,7 +22,7 @@ export class TestFactory {
         let main_resource: Resource = this[`get${document_class.name}`](id, include);
 
         let document_data: IDocumentData = main_resource.toObject();
-        this.fillDocumentDataIncludedRelatioships(document_data, include);
+        TestFactory.fillDocumentDataIncludedRelatioships(document_data, include);
 
         return document_data;
     }
@@ -31,7 +31,7 @@ export class TestFactory {
         let main_collection: DocumentCollection = this.getCollection(document_class, size, include);
 
         let document_data: IDocumentData = main_collection.toObject();
-        this.fillDocumentDataIncludedRelatioships(document_data, include);
+        TestFactory.fillDocumentDataIncludedRelatioships(document_data, include);
 
         return document_data;
     }
@@ -71,7 +71,7 @@ export class TestFactory {
         let book: Book = new Book();
         book.id = this.getId(id);
         book.ttl = ttl;
-        this.fillBookAttributes(book);
+        TestFactory.fillBookAttributes(book);
 
         // NOTE: add author
         (<IDataResource>book.relationships.author.data) = this.getDataResourceWithType('authors');
@@ -93,7 +93,7 @@ export class TestFactory {
         let author: Author = new Author();
         author.id = this.getId(id);
         author.ttl = ttl;
-        this.fillAuthorAttirbutes(author);
+        TestFactory.fillAuthorAttributes(author);
 
         // NOTE: add books
         author.relationships.books.data = author.relationships.books.data.concat(<Array<Book>>this.getDataResourcesWithType('books', 2));
@@ -119,7 +119,7 @@ export class TestFactory {
         let photo: Photo = new Photo();
         photo.id = this.getId(id);
         photo.ttl = ttl;
-        this.fillPhotoAttirbutes(photo);
+        TestFactory.fillPhotoAttirbutes(photo);
 
         return photo;
     }
@@ -139,7 +139,7 @@ export class TestFactory {
     }
 
     // TODO: create a dynamic attribute filler by data type and merge 3 methods in 1
-    private static fillAuthorAttirbutes(author: Author): Author {
+    private static fillAuthorAttributes(author: Author): Author {
         author.attributes.name = faker.name.firstName();
         author.attributes.date_of_birth = faker.date.past();
         author.attributes.date_of_death = faker.date.past();
@@ -175,7 +175,7 @@ export class TestFactory {
     }
 
     private static includeFromService(resource: Resource, relationship_alias: string, class_to_add: typeof Resource) {
-        if ('id' in resource.relationships[relationship_alias]) {
+        if ('id' in resource.relationships[relationship_alias].data) {
             this.includeHasOneFromService(resource, relationship_alias, class_to_add);
         } else if (resource.relationships[relationship_alias] instanceof DocumentCollection) {
             this.includeHasManyFromService(resource, relationship_alias, class_to_add);
@@ -194,7 +194,7 @@ export class TestFactory {
         }
         resource_to_add.id = relationship.data.id;
         let fill_method = `fill${class_to_add.name}Attributes`;
-        this[fill_method](resource_to_add);
+        TestFactory[fill_method](resource_to_add);
         resource.addRelationship(resource_to_add, relationship_alias);
     }
 
@@ -204,7 +204,7 @@ export class TestFactory {
             let resource_to_add: Resource = new class_to_add();
             resource_to_add.id = resource_relatioship.id;
             let fill_method = `fill${class_to_add.name}Attributes`;
-            this[fill_method](resource_to_add);
+            TestFactory[fill_method](resource_to_add);
             resources_to_add.push(resource_to_add);
         }
         // @TODO: cannot use addRelationships because its not working here... SHOULD BE FIXED
@@ -245,8 +245,8 @@ export class TestFactory {
 
                 return;
             }
-            let resource_class = this.resource_classes_by_type[relation_data.type];
-            if (resource_class) {
+            let resource_class = TestFactory.resource_classes_by_type[relation_data.type];
+            if (!resource_class) {
                 console.warn(`cannot find the required class for type ${relation_data.type}`);
 
                 return;
@@ -259,7 +259,7 @@ export class TestFactory {
         } else if (relationship_content instanceof DocumentCollection || relationship_content.data instanceof Array) {
             for (let has_many_relationship of (<DocumentCollection>resource.relationships[included_alias]).data) {
                 document_data.included.push(
-                    this[`get${this.resource_classes_by_type[has_many_relationship.type].name}`](has_many_relationship.id)
+                    this[`get${TestFactory.resource_classes_by_type[has_many_relationship.type].name}`](has_many_relationship.id)
                 );
             }
         }
@@ -274,10 +274,10 @@ export class TestFactory {
                 if (!document_data.data.relationships[included_alias].data) {
                     continue;
                 }
-                this.fillResourceRelationshipsInDocumentData(document_data, document_data.data, included_alias);
+                TestFactory.fillResourceRelationshipsInDocumentData(document_data, document_data.data, included_alias);
             }
             for (let resource of <Array<Resource>>document_data.data) {
-                this.fillResourceRelationshipsInDocumentData(document_data, resource, included_alias);
+                TestFactory.fillResourceRelationshipsInDocumentData(document_data, resource, included_alias);
             }
         }
     }

--- a/src/tests/get-resource.spec.ts
+++ b/src/tests/get-resource.spec.ts
@@ -100,7 +100,7 @@ describe('core methods', () => {
         });
     });
 
-    it(`resource should have the correct hasOne and hasMany relationships correspondig to the back end response's included resources,
+    it(`resource should have the correct hasOne and hasMany relationships corresponding to the back end response's included resources,
         including nested relationships`, async () => {
         let test_resource = new TestResource();
         test_resource.type = 'test_resources';
@@ -161,7 +161,7 @@ describe('core methods', () => {
             });
     });
 
-    it(`resource should have the correct hasOne and hasMany relationships correspondig to the back end response's included resources`, async () => {
+    it(`resource should have the correct hasOne and hasMany relationships corresponding to the back end response's included resources`, async () => {
         let test_resource = new TestResource();
         test_resource.type = 'test_resources';
         test_resource.id = '1';
@@ -219,7 +219,7 @@ describe('core methods', () => {
             });
     });
 
-    it(`if the back end sends a hasOne relatiohsip with a null data property, it should be set as null in the resulting resource`, async () => {
+    it(`if the back end sends a hasOne relationship with a null data property, it should be set as null in the resulting resource`, async () => {
         let test_resource = new TestResource();
         test_resource.type = 'test_resources';
         test_resource.id = '1';


### PR DESCRIPTION
Fix to has one relationships when building a resource from server. Has to be merged after https://github.com/reyesoft/ngx-jsonapi/pull/257, as it contains code used for testing in this PR.