### PR TITLE
Remove tests from public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
         "prettier-md:show": "prettier --parser markdown --single-quote es5 --tab-width 4 --print-width 140 --single-quote true --prose-wrap never \"**/*.md\"",
         "prettier-scss": "yarn prettier-scss:show --write",
         "prettier-scss:show": "prettier --parser scss --single-quote es5 --tab-width 4 --print-width 140 --single-quote true \"**/*.scss\"",
-        "precommit": "lint-staged"
+        "precommit": "lint-staged",
+        "prepare": "npm run build"
     },
     "lint-staged": {
         "*.ts": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "ngx-jsonapi-demo",
+    "version": "2.1.15",
     "description": "Demo app for JSON API library for Angular",
     "scripts": {
         "build": "ts-node ./build/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "ngx-jsonapi-demo",
+    "name": "ngx-jsonapi",
     "version": "2.1.15",
-    "description": "Demo app for JSON API library for Angular",
+    "description": "JSON API library for Angular",
     "scripts": {
         "build": "ts-node ./build/index.ts",
         "postbuild": "rimraf **/dist/**/*.ngsummary.json",

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -8,7 +8,3 @@ export { Resource } from './resource';
 export { DocumentResource } from './document-resource';
 export { DocumentCollection } from './document-collection';
 export { Service } from './service';
-export { Author, AuthorsService } from './tests/factories/authors.service';
-export { Book, BooksService } from './tests/factories/books.service';
-export { Photo, PhotosService } from './tests/factories/photos.service';
-export { TestFactory } from './tests/factories/test-factory';


### PR DESCRIPTION
This means we can drop the dependency on Faker.

(Faker is responsible for about half of our vendors.js bundle, and absolutely unnecessary for production use)