### PR TITLE
Fix cache consistency bug while deleting resources

### DIFF
--- a/src/services/cachememory.ts
+++ b/src/services/cachememory.ts
@@ -108,12 +108,12 @@ export class CacheMemory<R extends Resource = Resource> {
             return;
         }
         Base.forEach(this.collections, (value, url) => {
-            value.data.splice(
-                value.data.findIndex(
-                    (resource_on_collection: Resource) => resource_on_collection.type === type && resource_on_collection.id === id
-                ),
-                1
+            let resourceIndex = value.data.findIndex(
+                (resource_on_collection: Resource) => resource_on_collection.type === type && resource_on_collection.id === id
             );
+            if (resourceIndex > -1) {
+                value.data.splice(resourceIndex, 1);
+            }
         });
         resource.attributes = {}; // just for confirm deletion on view
 


### PR DESCRIPTION
**Context:**

`Cachememory.removeResource` is executed whenever a resource gets deleted.

This method aims to remove the deleted resource from the collections persisted in service cache.

**Bug:**

Resources that aren't directly related to the deleted resource get removed from the cache as well.

After investigation, we've found out this is caused by the `removeResource` method that loops over all the available collections, and removes one item every time, whether or not the target resource has been found.

This seems to be caused by the use of the `splice` method chained with `findIndex` : `findIndex` returns -1 when the resource isn't found, and `splice` removes the last item of the array.

**Resolution:**

If `findIndex` returns -1, avoid calling `splice` 