### PR TITLE
Add relationships meta to document resource

### DIFF
--- a/src/document-collection.ts
+++ b/src/document-collection.ts
@@ -54,6 +54,9 @@ export class RelatedDocumentCollection<R extends Resource = Resource> extends Do
         for (let dataresource of data_collection.data) {
             try {
                 let res = this.getResourceOrFail(dataresource);
+                if (dataresource.meta) {
+                    res.meta = dataresource.meta;
+                }
                 res.fill({ data: dataresource });
                 new_ids[dataresource.id] = dataresource.id;
                 (<Array<R>>this.data).push(<R>res);


### PR DESCRIPTION
Drupal jsonapi implementation add meta data to the relationship level between resources. For exemple a node with files. File information for all node are inside the resource and can be retrieved with ngx-jsonapi (size, filename, etc..). But some informations like alt or description of image (for exemple) are not in the "included" but are in the "relationship" level of the jsonapi.

This changes are made to be able to get this informations from drupal jsonapi.

Thank you.