### PR TITLE
fix: resolve nested relationships and allow sending them back to the server

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -213,12 +213,15 @@ export class Resource implements ICacheable {
             this.cache_last_update = data_object.data.cache_last_update;
         }
 
-        new ResourceRelationshipsConverter(
-            Converter.getService,
-            data_object.data.relationships || {},
-            this.relationships,
-            Converter.buildIncluded(data_object)
-        ).buildRelationships();
+        for (let i = 0; i < 2; i++) {
+            // do this twice so we already know all resources
+            new ResourceRelationshipsConverter(
+                Converter.getService,
+                data_object.data.relationships || {},
+                this.relationships,
+                Converter.buildIncluded(data_object)
+            ).buildRelationships();
+        }
 
         return true;
     }

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -79,8 +79,17 @@ export class Resource implements ICacheable {
                         included_relationships &&
                         included_relationships.indexOf(relation_alias) !== -1
                     ) {
-                        included_ids.push(temporal_id);
-                        included.push(resource.toObject({}).data);
+                        const {
+                            data: data,
+                            included: included_resources
+                        }: { data: IDataResource; included?: Array<any> } = resource.toObject(params);
+
+                        included_ids = [
+                            ...included_ids,
+                            temporal_id,
+                            ...(included_resources || []).map((result: IDataResource) => `${result.type}_${result.id}`)
+                        ];
+                        included = [...included, data, ...(included_resources || [])];
                     }
                 }
             } else {
@@ -120,8 +129,17 @@ export class Resource implements ICacheable {
                     included_relationships &&
                     included_relationships.indexOf(relation_alias) !== -1
                 ) {
-                    included_ids.push(temporal_id);
-                    included.push(relationship_data.toObject({}).data);
+                    const {
+                        data: data,
+                        included: included_resources
+                    }: { data: IDataResource; included?: Array<any> } = relationship_data.toObject(params);
+
+                    included_ids = [
+                        ...included_ids,
+                        temporal_id,
+                        ...(included_resources || []).map((result: IDataResource) => `${result.type}_${result.id}`)
+                    ];
+                    included = [...included, data, ...(included_resources || [])];
                 }
             }
         }


### PR DESCRIPTION
This is a new variant of my patch from 5 years ago: #203

The for() loop for triggering the `ResourceRelationshipsConverter` twice is certainly not perfect, but I am unsure on how to solve this in another way. I'm open for suggestions 😃 